### PR TITLE
only trigger DUO116 when shell=True

### DIFF
--- a/dlint/linters/bad_subprocess_use.py
+++ b/dlint/linters/bad_subprocess_use.py
@@ -30,36 +30,36 @@ class BadSubprocessUseLinter(bad_kwarg_use.BadKwargUseLinter):
 
     @property
     def kwargs(self):
-        def present_and_true(call, kwarg_name):
+        def present_or_not_false(call, kwarg_name):
             return (
-                tree.kwarg_true(call, kwarg_name)
-                and tree.kwarg_present(call, kwarg_name)
+                tree.kwarg_present(call, kwarg_name)
+                and not tree.kwarg_false(call, kwarg_name)
             )
 
         return [
             {
                 "module_path": "subprocess.call",
                 "kwarg_name": "shell",
-                "predicate": present_and_true,
+                "predicate": present_or_not_false,
             },
             {
                 "module_path": "subprocess.check_call",
                 "kwarg_name": "shell",
-                "predicate": present_and_true,
+                "predicate": present_or_not_false,
             },
             {
                 "module_path": "subprocess.check_output",
                 "kwarg_name": "shell",
-                "predicate": present_and_true,
+                "predicate": present_or_not_false,
             },
             {
                 "module_path": "subprocess.Popen",
                 "kwarg_name": "shell",
-                "predicate": present_and_true,
+                "predicate": present_or_not_false,
             },
             {
                 "module_path": "subprocess.run",
                 "kwarg_name": "shell",
-                "predicate": present_and_true,
+                "predicate": present_or_not_false,
             },
         ]

--- a/dlint/linters/bad_subprocess_use.py
+++ b/dlint/linters/bad_subprocess_use.py
@@ -34,26 +34,26 @@ class BadSubprocessUseLinter(bad_kwarg_use.BadKwargUseLinter):
             {
                 "module_path": "subprocess.call",
                 "kwarg_name": "shell",
-                "predicate": tree.kwarg_present,
+                "predicate": tree.kwarg_true,
             },
             {
                 "module_path": "subprocess.check_call",
                 "kwarg_name": "shell",
-                "predicate": tree.kwarg_present,
+                "predicate": tree.kwarg_true,
             },
             {
                 "module_path": "subprocess.check_output",
                 "kwarg_name": "shell",
-                "predicate": tree.kwarg_present,
+                "predicate": tree.kwarg_true,
             },
             {
                 "module_path": "subprocess.Popen",
                 "kwarg_name": "shell",
-                "predicate": tree.kwarg_present,
+                "predicate": tree.kwarg_true,
             },
             {
                 "module_path": "subprocess.run",
                 "kwarg_name": "shell",
-                "predicate": tree.kwarg_present,
-            }
+                "predicate": tree.kwarg_true,
+            },
         ]

--- a/dlint/linters/bad_subprocess_use.py
+++ b/dlint/linters/bad_subprocess_use.py
@@ -30,7 +30,7 @@ class BadSubprocessUseLinter(bad_kwarg_use.BadKwargUseLinter):
 
     @property
     def kwargs(self):
-        def present_or_not_false(call, kwarg_name):
+        def present_and_not_false(call, kwarg_name):
             return (
                 tree.kwarg_present(call, kwarg_name)
                 and not tree.kwarg_false(call, kwarg_name)
@@ -40,26 +40,26 @@ class BadSubprocessUseLinter(bad_kwarg_use.BadKwargUseLinter):
             {
                 "module_path": "subprocess.call",
                 "kwarg_name": "shell",
-                "predicate": present_or_not_false,
+                "predicate": present_and_not_false,
             },
             {
                 "module_path": "subprocess.check_call",
                 "kwarg_name": "shell",
-                "predicate": present_or_not_false,
+                "predicate": present_and_not_false,
             },
             {
                 "module_path": "subprocess.check_output",
                 "kwarg_name": "shell",
-                "predicate": present_or_not_false,
+                "predicate": present_and_not_false,
             },
             {
                 "module_path": "subprocess.Popen",
                 "kwarg_name": "shell",
-                "predicate": present_or_not_false,
+                "predicate": present_and_not_false,
             },
             {
                 "module_path": "subprocess.run",
                 "kwarg_name": "shell",
-                "predicate": present_or_not_false,
+                "predicate": present_and_not_false,
             },
         ]

--- a/dlint/linters/bad_subprocess_use.py
+++ b/dlint/linters/bad_subprocess_use.py
@@ -30,30 +30,36 @@ class BadSubprocessUseLinter(bad_kwarg_use.BadKwargUseLinter):
 
     @property
     def kwargs(self):
+        def present_and_true(call, kwarg_name):
+            return (
+                tree.kwarg_true(call, kwarg_name)
+                and tree.kwarg_present(call, kwarg_name)
+            )
+
         return [
             {
                 "module_path": "subprocess.call",
                 "kwarg_name": "shell",
-                "predicate": tree.kwarg_true,
+                "predicate": present_and_true,
             },
             {
                 "module_path": "subprocess.check_call",
                 "kwarg_name": "shell",
-                "predicate": tree.kwarg_true,
+                "predicate": present_and_true,
             },
             {
                 "module_path": "subprocess.check_output",
                 "kwarg_name": "shell",
-                "predicate": tree.kwarg_true,
+                "predicate": present_and_true,
             },
             {
                 "module_path": "subprocess.Popen",
                 "kwarg_name": "shell",
-                "predicate": tree.kwarg_true,
+                "predicate": present_and_true,
             },
             {
                 "module_path": "subprocess.run",
                 "kwarg_name": "shell",
-                "predicate": tree.kwarg_true,
+                "predicate": present_and_true,
             },
         ]

--- a/tests/test_bad_subprocess_use.py
+++ b/tests/test_bad_subprocess_use.py
@@ -90,45 +90,9 @@ class TestBadSubprocessUse(dlint.test.base.BaseTest):
         linter.visit(python_node)
 
         result = linter.get_results()
-        expected = [
-            dlint.linters.base.Flake8Result(
-                lineno=6,
-                col_offset=0,
-                message=dlint.linters.BadSubprocessUseLinter._error_tmpl
-            ),
-            dlint.linters.base.Flake8Result(
-                lineno=7,
-                col_offset=0,
-                message=dlint.linters.BadSubprocessUseLinter._error_tmpl
-            ),
-            dlint.linters.base.Flake8Result(
-                lineno=8,
-                col_offset=0,
-                message=dlint.linters.BadSubprocessUseLinter._error_tmpl
-            ),
-            dlint.linters.base.Flake8Result(
-                lineno=9,
-                col_offset=0,
-                message=dlint.linters.BadSubprocessUseLinter._error_tmpl
-            ),
-            dlint.linters.base.Flake8Result(
-                lineno=10,
-                col_offset=0,
-                message=dlint.linters.BadSubprocessUseLinter._error_tmpl
-            ),
-            dlint.linters.base.Flake8Result(
-                lineno=11,
-                col_offset=0,
-                message=dlint.linters.BadSubprocessUseLinter._error_tmpl
-            ),
-            dlint.linters.base.Flake8Result(
-                lineno=12,
-                col_offset=0,
-                message=dlint.linters.BadSubprocessUseLinter._error_tmpl
-            ),
-        ]
+        expected = []
 
-        assert result != expected
+        assert result == expected
 
 
 if __name__ == "__main__":

--- a/tests/test_bad_subprocess_use.py
+++ b/tests/test_bad_subprocess_use.py
@@ -19,11 +19,14 @@ class TestBadSubprocessUse(dlint.test.base.BaseTest):
             """
             import subprocess
 
+            command = "/bin/echo"
+
             subprocess.call(shell=True)
             subprocess.check_call(shell=True)
             subprocess.check_output(shell=True)
             subprocess.Popen(shell=True)
             subprocess.run(shell=True)
+            subprocess.run(command,shell=True)
             """
         )
 
@@ -32,16 +35,6 @@ class TestBadSubprocessUse(dlint.test.base.BaseTest):
 
         result = linter.get_results()
         expected = [
-            dlint.linters.base.Flake8Result(
-                lineno=4,
-                col_offset=0,
-                message=dlint.linters.BadSubprocessUseLinter._error_tmpl
-            ),
-            dlint.linters.base.Flake8Result(
-                lineno=5,
-                col_offset=0,
-                message=dlint.linters.BadSubprocessUseLinter._error_tmpl
-            ),
             dlint.linters.base.Flake8Result(
                 lineno=6,
                 col_offset=0,
@@ -57,9 +50,85 @@ class TestBadSubprocessUse(dlint.test.base.BaseTest):
                 col_offset=0,
                 message=dlint.linters.BadSubprocessUseLinter._error_tmpl
             ),
+            dlint.linters.base.Flake8Result(
+                lineno=9,
+                col_offset=0,
+                message=dlint.linters.BadSubprocessUseLinter._error_tmpl
+            ),
+            dlint.linters.base.Flake8Result(
+                lineno=10,
+                col_offset=0,
+                message=dlint.linters.BadSubprocessUseLinter._error_tmpl
+            ),
+            dlint.linters.base.Flake8Result(
+                lineno=11,
+                col_offset=0,
+                message=dlint.linters.BadSubprocessUseLinter._error_tmpl
+            ),
         ]
 
         assert result == expected
+
+    def test_subprocess_usage(self):
+        python_node = self.get_ast_node(
+            """
+            import subprocess
+
+            command = "/bin/echo"
+
+            subprocess.call(command)
+            subprocess.call(shell=False)
+            subprocess.check_call(shell=False)
+            subprocess.check_output(shell=False)
+            subprocess.Popen(shell=False)
+            subprocess.run(command)
+            subprocess.run(shell=False)
+            """
+        )
+
+        linter = dlint.linters.BadSubprocessUseLinter()
+        linter.visit(python_node)
+
+        result = linter.get_results()
+        expected = [
+            dlint.linters.base.Flake8Result(
+                lineno=6,
+                col_offset=0,
+                message=dlint.linters.BadSubprocessUseLinter._error_tmpl
+            ),
+            dlint.linters.base.Flake8Result(
+                lineno=7,
+                col_offset=0,
+                message=dlint.linters.BadSubprocessUseLinter._error_tmpl
+            ),
+            dlint.linters.base.Flake8Result(
+                lineno=8,
+                col_offset=0,
+                message=dlint.linters.BadSubprocessUseLinter._error_tmpl
+            ),
+            dlint.linters.base.Flake8Result(
+                lineno=9,
+                col_offset=0,
+                message=dlint.linters.BadSubprocessUseLinter._error_tmpl
+            ),
+            dlint.linters.base.Flake8Result(
+                lineno=10,
+                col_offset=0,
+                message=dlint.linters.BadSubprocessUseLinter._error_tmpl
+            ),
+            dlint.linters.base.Flake8Result(
+                lineno=11,
+                col_offset=0,
+                message=dlint.linters.BadSubprocessUseLinter._error_tmpl
+            ),
+            dlint.linters.base.Flake8Result(
+                lineno=12,
+                col_offset=0,
+                message=dlint.linters.BadSubprocessUseLinter._error_tmpl
+            ),
+        ]
+
+        assert result != expected
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Using `shell=False`, to make sure default arguments are set, would trigger `DUO116`:`subprocess module with shell=True`

This PR allows `shell=False`.

```sh
$ cat -n /tmp/shell.py 
     1  #!/usr/bin/python3
     2  
     3  import subprocess
     4  
     5  command = "/bin/echo"
     6  
     7  subprocess.call(command, shell=False)
     8  subprocess.call(command, shell=True)
     9  subprocess.call(command, shell=False)
$ python3 -m flake8 /tmp/shell.py 
/tmp/shell.py:3:1: S404 Consider possible security implications associated with subprocess module.
/tmp/shell.py:7:1: S603 subprocess call - check for execution of untrusted input.
/tmp/shell.py:8:1: DUO116 use of "shell=True" is insecure in "subprocess" module
/tmp/shell.py:8:1: S602 subprocess call with shell=True identified, security issue.
/tmp/shell.py:9:1: S603 subprocess call - check for execution of untrusted input.
$ python3 -m flake8 -h
[...]
Installed plugins: dlint: 0.10.3, flake8-bandit: 2.1.2, flake8-bugbear:
20.1.4, flake8-darglint: 1.5.5, flake8-executable: 2.0.4, flake8_deprecated:
1.2, mccabe: 0.6.1, naming: 0.11.1, pycodestyle: 2.6.0, pyflakes: 2.2.0,
radon: 4.3.2
```

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>