### PR TITLE
Speedup get_plugin_linter_classes

### DIFF
--- a/dlint/extension.py
+++ b/dlint/extension.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import functools
 import importlib
 import inspect
 import pkgutil
@@ -56,6 +57,7 @@ class Flake8Extension(object):
         cls.options = options
 
     @classmethod
+    @functools.lru_cache()
     def get_plugin_linter_classes(cls):
         module_prefix = 'dlint_plugin_'
         class_prefix = 'Dlint'


### PR DESCRIPTION
get_plugin_linter_classes is  called once per file being processed and can take hundreds of ms per file, which over a large code base of hundreds or thousands of files slows things down noticeably. use an lru_cache here as the code should always return the same thing inside a single process.


Closes #58 